### PR TITLE
Point to the correct main js file

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "author": "Nick Payne <nick@kurai.co.uk>",
   "license": "MIT",
   "readmeFilename": "README.md",
-  "main": "bootbox.js",
+  "main": "src/bootbox.js",
   "devDependencies": {
     "chai": "^3.5.0",
     "grunt": "~0.4.1",


### PR DESCRIPTION
Running locally, NPM fails to find the Bootbox index file as the package JSON references the incorrect main location (i.e. `bootbox.js` vs. `src/bootbox.js`.